### PR TITLE
- [x] Fix `--dodump`: add proactive dump after email step (before MFA detection) - [x] Fix `--dodump`: add proactive dump when MFA screen is detected (step 1.5) - [x] Fix `--dodump`: add proactive dump after password submission (step 2.5) - [x] Add Number Matching detection in post-password race (step 2.5) - [x] Extract number from `.displaySign` and print to terminal - [x] Wait silently for page to auto-advance after phone approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OneNote to Obsidian Exporter
 
-![App Icon](build/icon.png)
+![App Icon](docs/MSOneNoteExporter_Icon_Adobe.svg)
 
 A robust, automated tool to export Microsoft OneNote notebooks into Obsidian-compatible Markdown folders. This tool preserves your notebook's hierarchy, downloads all attachments (PDFs, images, videos), and correctly resolves internal links.
 
@@ -78,6 +78,7 @@ node src/index.js login --login "your-email@example.com" --password "your-passwo
 
 > [!TIP]
 > **MFA Support**: The tool includes an advanced "Resilient MFA" handler. While some accounts may still require a one-time manual `login` in visible mode, the automated `login --login email --password pass` command now supports many MFA flows (like switching to password entry or "Stay signed in" prompts) automatically.
+
 
 ### 2. Interactive Export
 List available notebooks and select one to export.

--- a/docs/MFA Number Maching & --dodump Fix-implementation_plan.md
+++ b/docs/MFA Number Maching & --dodump Fix-implementation_plan.md
@@ -1,0 +1,97 @@
+# MFA Number Matching & `--dodump` Fix
+
+## Background
+
+The login flow in `src/auth.js` needs two improvements:
+
+1. **`--dodump` is not producing dumps** — dumps are buried in `catch` blocks only triggered by errors. Key diagnostic states (e.g. the MFA detection step) are never dumped even though the flag is passed.
+2. **New MFA scenario (Number Matching)** — When logging in to corporate accounts (e.g. `@msbs.fr`), Microsoft may show an "Approve sign in request" screen with a 2-digit number (see screenshot). The user must open Microsoft Authenticator on their phone, enter that number, then tap OK. The browser page then automatically advances — **no further browser interaction is needed**.
+
+The goal is to handle this headlessly: detect the screen, extract and display the number in the terminal, then wait (silently) for the phone approval to complete and the page to advance.
+
+---
+
+## Proposed Changes
+
+### `src/auth.js`
+
+This is the only file requiring changes, affecting both the `login()` (CLI) and `loginForElectron()` (GUI) functions.
+
+---
+
+#### Fix 1: `--dodump` proactive dumps
+
+Currently dumps only occur inside `catch` blocks after errors. The fix adds **proactive diagnostic snapshots** at key decision points when `credentials.dodump` is truthy:
+
+- After email submission (before MFA detection)
+- When MFA / intermediate screens are detected
+- After password submission (before post-password MFA check)
+- At any post-password MFA screen
+
+This makes `--dodump` actually useful for diagnosing what screen the automation sees.
+
+---
+
+#### Fix 2: Number Matching MFA detection (CLI `login()`)
+
+After password submission (step 2.5), extend the `verificationScreen` race to also detect the Number Matching screen. New selectors:
+
+| Selector | Purpose |
+|---|---|
+| `text=/Approve sign in request/i` | The heading on the number-match screen |
+| `text=/Enter the number shown/i` | Subtitle text on the same screen |
+| `.displaySign` | The `<div>` Microsoft uses to show the 2-digit number (confirmed in HTML) |
+
+**Detection → action flow:**
+
+```
+POST PASSWORD SUBMIT
+        │
+        ├─ "Verify your identity" / "Enter code" / input[name="otc"]
+        │        └─► Prompt user for OTC code (existing behavior)
+        │
+        └─ "Approve sign in request" / displaySign element found
+                 └─► Extract number from .displaySign
+                     └─► Print to terminal: "ACTION REQUIRED: Open Microsoft Authenticator and enter: 47"
+                         └─► Wait up to 120s for page to auto-navigate away (phone approval)
+                             └─► If page advances → continue to "Stay signed in?" prompt
+                                 └─► If timeout → throw error
+```
+
+**Key implementation notes:**
+- The number is extracted with: `page.$eval('.displaySign', el => el.textContent.trim())`
+- After extraction we do **NOT** fill any input or click any button. We simply `waitForURL` or wait for the MFA page to disappear (the Authenticator app approval triggers the server-side redirect).
+- Wait strategy: `Promise.race([page.waitForURL(...not login page...), page.waitForSelector('.displaySign', {state: 'hidden'})])` with a 120s timeout.
+
+---
+
+#### Fix 3: Number Matching MFA detection (Electron `loginForElectron()`)
+
+Same logic as Fix 2 but uses `sendEvent` instead of `console.log`:
+
+- `sendEvent('mfa-number-match', { number: '47' })` — tells the renderer to display the number to the user
+- Then waits for the page to auto-advance (same race as above — no IPC round-trip needed from phone approval)
+
+---
+
+## Verification Plan
+
+### Manual verification (automated login with `--dodump`)
+```bash
+node src/index.js login --login <email> --password <password> --dodump
+```
+- Confirm HTML dumps are created at each step regardless of success/failure
+
+### Manual verification (MFA Number Matching)
+```bash
+node src/index.js login --login <email> --password <password>
+```
+- Confirm the number appears in the terminal
+- Open Microsoft Authenticator, enter the number, tap OK
+- Confirm the session is saved to `auth.json`
+
+### Regression check
+```bash
+node src/index.js login --login <email> --password <password>
+```
+- Verify non-MFA corporate accounts still authenticate (no number-match screen → falls through cleanly)

--- a/docs/MFA Number Maching + --dodump Fix-commitmsg.md
+++ b/docs/MFA Number Maching + --dodump Fix-commitmsg.md
@@ -1,0 +1,15 @@
+# Task: MFA Number Matching + `--dodump` Fix
+
+## `src/auth.js` — CLI `login()` function
+- [x] Fix `--dodump`: add proactive dump after email step (before MFA detection)
+- [x] Fix `--dodump`: add proactive dump when MFA screen is detected (step 1.5)
+- [x] Fix `--dodump`: add proactive dump after password submission (step 2.5)
+- [x] Add Number Matching detection in post-password race (step 2.5)
+- [x] Extract number from `.displaySign` and print to terminal
+- [x] Wait silently for page to auto-advance after phone approval
+
+## `src/auth.js` — Electron `loginForElectron()` function
+- [x] Fix `--dodump`: same proactive dumps as CLI version
+- [x] Add Number Matching detection in post-password race (step 2.5)
+- [x] Extract number and emit `sendEvent('mfa-number-match', { number })`
+- [x] Wait silently for page to auto-advance (display popup hint on Electron side)

--- a/docs/Standardized Terminal Output Walkthrough.md
+++ b/docs/Standardized Terminal Output Walkthrough.md
@@ -1,0 +1,37 @@
+# Standardized Terminal Output Walkthrough
+2026/04/01
+Terminal output has been standardized across the application using a new unified logger.
+
+## Changes Made
+- Created [src/utils/logger.js](src/utils/logger.js).
+- Integrated logger into:
+    - [index.js](src/index.js)
+    - [auth.js](src/auth.js)
+    - [navigator.js](src/navigator.js)
+    - [exporter.js](src/exporter.js)
+    - [scrapers.js](src/scrapers.js)
+    - [retry.js](src/utils/retry.js)
+
+## Verification Results
+
+### New Format Pattern
+All logs now follow this pattern:
+`[MMM DD HH:mm:ss] [LEVEL] Message`
+
+### Terminal Output Example
+Running `onenote-export check`:
+```text
+[Feb 07 22:33:59] [SUCCESS] Authentication file found.
+```
+
+### Bug Fixes
+- Fixed `ReferenceError: logger is not defined` in [src/scrapers.js](src/scrapers.js) by replacing `logger` calls with `console.debug` inside `frame.evaluate` blocks. This ensures scraper debugging doesn't crash when running in the browser context.
+
+### Automated Tests
+Existing tests for parsing and link resolution passed successfully, ensuring no regressions.
+```text
+PASS  test/parser.test.js
+PASS  test/linkResolver.test.js
+Test Suites: 2 passed, 2 total
+Tests:       22 passed, 22 total
+```

--- a/src/auth.js
+++ b/src/auth.js
@@ -120,6 +120,13 @@ async function login(credentials = {}) {
                 throw e;
             }
 
+            // Proactive dump after email step (before MFA detection)
+            if (credentials.dodump) {
+                const debugFile = 'debug_after_email.html';
+                await fs.writeFile(debugFile, await page.content());
+                logger.debug(`[dodump] Post-email state dumped to ${debugFile}`);
+            }
+
             // 1.5. Handle intermediate screens (MFA selection, "Other ways to sign in")
             try {
                 // Re-poll the page state after the stabilization delay
@@ -151,6 +158,13 @@ async function login(credentials = {}) {
                 });
 
                 logger.debug(`Intermediate screen detection result: ${result}`);
+
+                // Proactive dump when intermediate screen is reached
+                if (credentials.dodump) {
+                    const debugFile = 'debug_intermediate_screen.html';
+                    await fs.writeFile(debugFile, await page.content());
+                    logger.debug(`[dodump] Intermediate screen state dumped to ${debugFile}`);
+                }
 
                 if (result === 'other_ways' || pageHeading.includes('Get a code') || pageHeading.includes('Verify your identity')) {
                     logger.info('Detected MFA/Verification screen. Attempting to locate "Other ways to sign in"...');
@@ -277,16 +291,65 @@ async function login(credentials = {}) {
                 throw e;
             }
 
+            // Proactive dump after password submission (before post-password MFA check)
+            if (credentials.dodump) {
+                const debugFile = 'debug_after_password.html';
+                await fs.writeFile(debugFile, await page.content());
+                logger.debug(`[dodump] Post-password state dumped to ${debugFile}`);
+            }
+
             // 2.5. Handle post-password MFA/Verification if needed
             try {
                 // Check if we are stuck on a verification screen
+                // Includes new Number Matching MFA ("Approve sign in request" with a displayed number)
                 const verificationScreen = await Promise.race([
-                    page.waitForSelector('text="Verify your identity"', { timeout: 5000 }).then(() => 'verify'),
-                    page.waitForSelector('text="Enter code"', { timeout: 5000 }).then(() => 'enter_code'),
-                    page.waitForSelector('input[name="otc"]', { timeout: 5000 }).then(() => 'otc_input')
+                    page.waitForSelector('text="Verify your identity"', { timeout: 10000 }).then(() => 'verify'),
+                    page.waitForSelector('text="Enter code"', { timeout: 10000 }).then(() => 'enter_code'),
+                    page.waitForSelector('input[name="otc"]', { timeout: 10000 }).then(() => 'otc_input'),
+                    // Number Matching MFA: corporate accounts show a number the user must enter in Authenticator
+                    page.waitForSelector('text=/Approve sign in request/i', { timeout: 10000 }).then(() => 'number_match'),
+                    page.waitForSelector('.displaySign', { timeout: 10000 }).then(() => 'number_match'),
                 ]).catch(() => null);
 
-                if (verificationScreen) {
+                if (credentials.dodump) {
+                    const debugFile = 'debug_post_password_mfa.html';
+                    await fs.writeFile(debugFile, await page.content());
+                    logger.debug(`[dodump] Post-password MFA screen state dumped to ${debugFile}`);
+                }
+
+                if (verificationScreen === 'number_match') {
+                    // ── Number Matching MFA (corporate accounts) ──────────────────────────
+                    // Microsoft shows a 2-digit number; user must enter it in Authenticator
+                    // app on their phone and tap OK — the page then auto-advances.
+                    // No browser interaction is required after extracting the number.
+                    logger.warn('Number Matching MFA detected ("Approve sign in request" screen).');
+
+                    let matchNumber = '??';
+                    try {
+                        matchNumber = await page.$eval('.displaySign', el => el.textContent.trim());
+                    } catch (_) {
+                        logger.debug('Could not extract number from .displaySign — user may still see it if --notheadless is used.');
+                    }
+
+                    logger.step('══════════════════════════════════════════════════════');
+                    logger.step(`  ACTION REQUIRED: Open Microsoft Authenticator on your phone.`);
+                    logger.step(`  Enter the number:  ${matchNumber}`);
+                    logger.step(`  Then tap "Yes" / "Approve" in the app.`);
+                    logger.step('══════════════════════════════════════════════════════');
+                    logger.info('Waiting for phone approval (up to 120 seconds)...');
+
+                    // Wait for the page to auto-advance after phone approval.
+                    // The MFA page disappears and Microsoft redirects to the next step.
+                    await Promise.race([
+                        page.waitForSelector('.displaySign', { state: 'hidden', timeout: 120000 }),
+                        page.waitForURL(url => !url.toString().includes('login.microsoftonline.com'), { timeout: 120000 }),
+                        page.waitForSelector('text=/Stay signed in/i', { timeout: 120000 }),
+                    ]);
+
+                    logger.success('Phone approval received. Continuing login flow...');
+
+                } else if (verificationScreen) {
+                    // ── OTC / TOTP code (email / authenticator code) ──────────────────────
                     logger.warn('MFA/Verification screen detected.');
                     logger.step('A verification code is required. Please check your email or authenticator app.');
 
@@ -512,6 +575,13 @@ async function loginForElectron(credentials = {}, sendEvent, ipcMain) {
                 throw e;
             }
 
+            // Proactive dump after email step (before MFA detection)
+            if (credentials.dodump) {
+                const debugFile = 'debug_after_email.html';
+                await fs.writeFile(debugFile, await page.content());
+                log('debug', `[dodump] Post-email state dumped to ${debugFile}`);
+            }
+
             // 1.5. Handle intermediate screens (MFA selection)
             try {
                 const pageTitle = (await page.title()).trim();
@@ -536,6 +606,13 @@ async function loginForElectron(credentials = {}, sendEvent, ipcMain) {
                 });
 
                 log('debug', `Intermediate screen detection result: ${result}`);
+
+                // Proactive dump when intermediate screen is reached
+                if (credentials.dodump) {
+                    const debugFile = 'debug_intermediate_screen.html';
+                    await fs.writeFile(debugFile, await page.content());
+                    log('debug', `[dodump] Intermediate screen state dumped to ${debugFile}`);
+                }
 
                 if (result === 'other_ways' || pageHeading.includes('Get a code') || pageHeading.includes('Verify your identity')) {
                     log('info', 'Detected MFA/Verification screen. Attempting to locate "Other ways to sign in"...');
@@ -609,15 +686,61 @@ async function loginForElectron(credentials = {}, sendEvent, ipcMain) {
                 throw e;
             }
 
+            // Proactive dump after password submission (before post-password MFA check)
+            if (credentials.dodump) {
+                const debugFile = 'debug_after_password.html';
+                await fs.writeFile(debugFile, await page.content());
+                log('debug', `[dodump] Post-password state dumped to ${debugFile}`);
+            }
+
             // 2.5. Handle post-password MFA/Verification (OTC prompt via GUI dialog)
+            //      Also handles Number Matching MFA (corporate accounts)
             try {
                 const verificationScreen = await Promise.race([
-                    page.waitForSelector('text="Verify your identity"', { timeout: 5000 }).then(() => 'verify'),
-                    page.waitForSelector('text="Enter code"', { timeout: 5000 }).then(() => 'enter_code'),
-                    page.waitForSelector('input[name="otc"]', { timeout: 5000 }).then(() => 'otc_input')
+                    page.waitForSelector('text="Verify your identity"', { timeout: 10000 }).then(() => 'verify'),
+                    page.waitForSelector('text="Enter code"', { timeout: 10000 }).then(() => 'enter_code'),
+                    page.waitForSelector('input[name="otc"]', { timeout: 10000 }).then(() => 'otc_input'),
+                    // Number Matching MFA: corporate accounts show a number to enter in Authenticator
+                    page.waitForSelector('text=/Approve sign in request/i', { timeout: 10000 }).then(() => 'number_match'),
+                    page.waitForSelector('.displaySign', { timeout: 10000 }).then(() => 'number_match'),
                 ]).catch(() => null);
 
-                if (verificationScreen) {
+                if (credentials.dodump) {
+                    const debugFile = 'debug_post_password_mfa.html';
+                    await fs.writeFile(debugFile, await page.content());
+                    log('debug', `[dodump] Post-password MFA screen state dumped to ${debugFile}`);
+                }
+
+                if (verificationScreen === 'number_match') {
+                    // ── Number Matching MFA (corporate accounts) ──────────────────────────
+                    // Microsoft shows a 2-digit number; user must enter it in Authenticator
+                    // on their phone and tap OK — the page then auto-advances.
+                    log('warn', 'Number Matching MFA detected ("Approve sign in request" screen).');
+
+                    let matchNumber = '??';
+                    try {
+                        matchNumber = await page.$eval('.displaySign', el => el.textContent.trim());
+                    } catch (_) {
+                        log('debug', 'Could not extract number from .displaySign.');
+                    }
+
+                    // Notify the Electron renderer — it will show a waiting popup to the user
+                    sendEvent('mfa-number-match', { number: matchNumber });
+                    log('warn', `Number Matching MFA — user must enter ${matchNumber} in Microsoft Authenticator.`);
+
+                    // Wait silently for phone approval to auto-advance the page (no browser action needed)
+                    log('info', 'Waiting for phone approval (up to 120 seconds)...');
+                    await Promise.race([
+                        page.waitForSelector('.displaySign', { state: 'hidden', timeout: 120000 }),
+                        page.waitForURL(url => !url.toString().includes('login.microsoftonline.com'), { timeout: 120000 }),
+                        page.waitForSelector('text=/Stay signed in/i', { timeout: 120000 }),
+                    ]);
+
+                    log('success', 'Phone approval received. Continuing login flow...');
+                    sendEvent('mfa-number-match-approved', {});
+
+                } else if (verificationScreen) {
+                    // ── OTC / TOTP code prompt ─────────────────────────────────────────────
                     log('warn', 'MFA/Verification screen detected.');
                     log('step', 'A verification code is required. Please check your email or authenticator app.');
 


### PR DESCRIPTION
- [x] Fix `--dodump`: same proactive dumps as CLI version
- [x] Add Number Matching detection in post-password race (step 2.5)
- [x] Extract number and emit `sendEvent('mfa-number-match', { number })`
- [x] Wait silently for page to auto-advance (display popup hint on Electron side)
